### PR TITLE
88 schema smallint insertion bug

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE DIM_plant (
     FOREIGN KEY (botanist_id) REFERENCES DIM_origin_location(location_id)
 );
 
-CREATE TABLE FACT_plant_reading_2 (
+CREATE TABLE FACT_plant_reading (
     plant_health_id BIGINT IDENTITY(1,1) PRIMARY KEY,
     temperature FLOAT,
     soil_moisture FLOAT,


### PR DESCRIPTION
## Description
Hotfix PR for #88. Table schema did not allow for a value of more than 37000 and would not continue inserting. The table has been manually changed to conserve the data and the schema has been altered.

## How has this been tested?
Tested by changing schema and seeing if data is now inserted correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code has a pylint score over 8.5/9.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.